### PR TITLE
Renamed package name in setup to make pip happy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md', 'r') as fd:
     long_description = fd.read()
 
 setup(
-    name='ingest_data_model',
+    name='adsingestschema',
     version=get_git_version(default="v0.0.1"),
     url='http://github.com/adsabs/ingest_data_model/',
     license='MIT',


### PR DESCRIPTION
When trying to pip install this in another package as a dependency, getting the following error:
```Discarding git+https://github.com/adsabs/ingest_data_model@v1.0.2#egg=adsingestschema: Requested ingest-data-model from git+https://github.com/adsabs/ingest_data_model@v1.0.2#egg=adsingestschema (from adsingestp==0.0.1) has inconsistent name: filename has 'adsingestschema', but metadata has 'ingest-data-model'```

Renaming the package in setup fixes the metadata name to allow install.